### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/vitorpy/noreposts-atproto-feed/security/code-scanning/1](https://github.com/vitorpy/noreposts-atproto-feed/security/code-scanning/1)

To remediate the issue, a `permissions:` block should be added to the workflow. The minimal safe starting point is to set `contents: read`, which only permits reading repository contents (not writing or administrative actions) and is sufficient for most workflows that only check out code. Since none of the steps in this workflow (including those using `actions/checkout` and `actions/cache`, and deployments via SSH) require write access to GitHub resources, the most restrictive permissions possible should be applied at either the workflow root or at the job level. For simplicity and broad coverage, it is recommended to add the following at the root (before `jobs:`):

```yaml
permissions:
  contents: read
```

This change should be made in `.github/workflows/deploy.yml` following the workflow name and triggers. No new imports or external libraries are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
